### PR TITLE
Added additional methods to the Request class #14

### DIFF
--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -60,4 +60,38 @@ class Request
     {
         return '';
     }
+
+    public static function get(string $key, $default = null): ?string
+    {
+        return isset($_GET[$key]) ? filter_input(INPUT_GET, $key, FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+    }
+
+    public static function post(string $key, $default = null): ?string
+    {
+        return isset($_POST[$key]) ? filter_input(INPUT_POST, $key, FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+    }
+
+    public static function cookie(string $key, $default = null): ?string
+    {
+        return isset($_COOKIE[$key]) ? filter_var($_COOKIE[$key], FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+    }
+
+    public static function has(string $type, $keys): bool
+    {
+        if (!is_array($keys)) {
+            $keys = [$keys];
+        }
+
+        foreach ($keys as $key) {
+            if ($type == 'GET' && self::get($key) === null) {
+                return false;
+            }
+
+            if ($type == 'POST' && self::post($key) === null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -63,17 +63,17 @@ class Request
 
     public static function get(string $key, $default = null): ?string
     {
-        return isset($_GET[$key]) ? filter_input(INPUT_GET, $key, FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+        return (isset($_GET[$key]) && trim($_GET[$key]) !== "") ? $_GET[$key] : $default;
     }
 
     public static function post(string $key, $default = null): ?string
     {
-        return isset($_POST[$key]) ? filter_input(INPUT_POST, $key, FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+        return (isset($_POST[$key]) && trim($_POST[$key]) !== "") ? $_POST[$key] : $default;
     }
 
     public static function cookie(string $key, $default = null): ?string
     {
-        return isset($_COOKIE[$key]) ? filter_var($_COOKIE[$key], FILTER_SANITIZE_SPECIAL_CHARS) : $default;
+        return (isset($_COOKIE[$key]) && trim($_COOKIE[$key]) !== "") ? $_COOKIE[$key] : $default;
     }
 
     public static function has(string $type, $keys): bool
@@ -83,11 +83,7 @@ class Request
         }
 
         foreach ($keys as $key) {
-            if ($type == 'GET' && self::get($key) === null) {
-                return false;
-            }
-
-            if ($type == 'POST' && self::post($key) === null) {
+            if ( self::$type($key) === null ) {
                 return false;
             }
         }


### PR DESCRIPTION
This commit adds the following methods to the Request class:

- get: This method attempts to fetch a value from the $_GET superglobal using the provided key. If the key does not exist, it returns a provided default value. The returned value is sanitized for special characters.

- post: Similar to the 'get' method, this method tries to retrieve a value from the $_POST superglobal using the given key. If the key doesn't exist, it returns a provided default value. The returned value is also sanitized for special characters.

- cookie: This method fetches a value from the $_COOKIE superglobal using a specified key. If the key does not exist, it returns a provided default value. The returned value is sanitized for special characters.

- has: This method checks if a specific key or array of keys exists in the $_GET or $_POST superglobals. It utilizes the 'get' and 'post' methods for this check and returns true if the key(s) exist, otherwise false.